### PR TITLE
Support for prefixes and suffixes on generated java classes

### DIFF
--- a/graphql-java-client-runtime/src/test/java/com/graphql_java_generator/util/GraphqlUtilsTest.java
+++ b/graphql-java-client-runtime/src/test/java/com/graphql_java_generator/util/GraphqlUtilsTest.java
@@ -17,6 +17,8 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
 
+import com.graphql_java_generator.domain.client.forum.CustomScalarRegistryInitializer;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -37,6 +39,11 @@ import graphql.scalars.ExtendedScalars;
 
 @Execution(ExecutionMode.CONCURRENT)
 class GraphqlUtilsTest {
+
+	@BeforeAll
+	public static void initCustomScalarRegistry() {
+		CustomScalarRegistryInitializer.initCustomScalarRegistry();
+	}
 
 	GraphqlUtils graphqlUtils = new GraphqlUtils();
 

--- a/graphql-maven-plugin-logic/src/main/java/com/graphql_java_generator/plugin/conf/CommonConfiguration.java
+++ b/graphql-maven-plugin-logic/src/main/java/com/graphql_java_generator/plugin/conf/CommonConfiguration.java
@@ -115,6 +115,55 @@ public interface CommonConfiguration {
 	public boolean isAddRelayConnections();
 
 	/**
+	 *  An optional prefix for the generated java classes for GraphQL types.
+	 */
+	public String getTypePrefix();
+
+	/**
+	 *  An optional suffix for the generated java classes for GraphQL types.
+	 */
+	public String getTypeSuffix();
+
+	/**
+	 *  An optional prefix for the generated java classes for GraphQL input objects.
+	 */
+	public String getInputPrefix();
+
+	/**
+	 *  An optional suffix for the generated java classes for GraphQL input objects.
+	 */
+	public String getInputSuffix();
+
+	/**
+	 *  An optional prefix for the generated java classes for GraphQL unions.
+	 */
+	public String getUnionPrefix();
+
+	/**
+	 *  An optional suffix for the generated java classes for GraphQL unions.
+	 */
+	public String getUnionSuffix();
+
+	/**
+	 *  An optional prefix for the generated java classes for GraphQL interfaces.
+	 */
+	public String getInterfacePrefix();
+
+	/**
+	 *  An optional prefix for the generated java classes for GraphQL interfaces.
+	 */
+	public String getInterfaceSuffix();
+	/**
+	 *  An optional prefix for the generated java classes for GraphQL enums.
+	 */
+	public String getEnumPrefix();
+
+	/**
+	 *  An optional suffix for the generated java classes for GraphQL enums.
+	 */
+	public String getEnumSuffix();
+
+	/**
 	 * This method is used only in {@link GeneratePojoConfiguration}.
 	 * 
 	 * @return The {@link GeneratePojoConfiguration} implementation of this method always returns true
@@ -164,6 +213,16 @@ public interface CommonConfiguration {
 									.map(entry -> String.format("%s=%s", entry.getKey(), entry.getValue()))
 									.collect(Collectors.joining(", "))
 							: ""));
+			logger.debug("    typePrefix: " + getTypePrefix());
+			logger.debug("    typeSuffix: " + getTypeSuffix());
+			logger.debug("    inputPrefix: " + getInputPrefix());
+			logger.debug("    inputSuffix: " + getInputSuffix());
+			logger.debug("    enumPrefix: " + getEnumPrefix());
+			logger.debug("    enumSuffix: " + getEnumSuffix());
+			logger.debug("    interfacePrefix: " + getInterfacePrefix());
+			logger.debug("    interfaceSuffix: " + getInterfaceSuffix());
+			logger.debug("    unionPrefix: " + getUnionPrefix());
+			logger.debug("    unionSuffix: " + getUnionSuffix());
 		}
 	}
 

--- a/graphql-maven-plugin-logic/src/main/java/com/graphql_java_generator/plugin/generate_code/GenerateCodeGenerator.java
+++ b/graphql-maven-plugin-logic/src/main/java/com/graphql_java_generator/plugin/generate_code/GenerateCodeGenerator.java
@@ -615,6 +615,56 @@ public class GenerateCodeGenerator implements Generator {
 					}
 
 					@Override
+					public String getTypePrefix() {
+						return configuration.getTypePrefix();
+					}
+
+					@Override
+					public String getTypeSuffix() {
+						return configuration.getTypeSuffix();
+					}
+
+					@Override
+					public String getInputPrefix() {
+						return configuration.getInputPrefix();
+					}
+
+					@Override
+					public String getInputSuffix() {
+						return configuration.getInputSuffix();
+					}
+
+					@Override
+					public String getUnionPrefix() {
+						return configuration.getUnionPrefix();
+					}
+
+					@Override
+					public String getUnionSuffix() {
+						return configuration.getUnionSuffix();
+					}
+
+					@Override
+					public String getInterfacePrefix() {
+						return configuration.getInterfacePrefix();
+					}
+
+					@Override
+					public String getInterfaceSuffix() {
+						return configuration.getInterfaceSuffix();
+					}
+
+					@Override
+					public String getEnumPrefix() {
+						return configuration.getEnumPrefix();
+					}
+
+					@Override
+					public String getEnumSuffix() {
+						return configuration.getEnumSuffix();
+					}
+
+					@Override
 					public String getResourceEncoding() {
 						return "UTF-8";
 					}

--- a/graphql-maven-plugin-logic/src/main/java/com/graphql_java_generator/plugin/language/impl/AbstractType.java
+++ b/graphql-maven-plugin-logic/src/main/java/com/graphql_java_generator/plugin/language/impl/AbstractType.java
@@ -2,8 +2,11 @@ package com.graphql_java_generator.plugin.language.impl;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.graphql_java_generator.plugin.DocumentParser;
 import com.graphql_java_generator.plugin.conf.CommonConfiguration;
@@ -84,6 +87,22 @@ public abstract class AbstractType implements Type {
 	@Override
 	public String getClassSimpleName() {
 		return getJavaName();
+	}
+
+    @Override
+    public String getJavaName() {
+        // Optionally add a prefix and/or suffix to the name
+		String name = Stream.of(getPrefix(), getName(), getSuffix())
+				.filter(Objects::nonNull).collect(Collectors.joining());
+
+		return GraphqlUtils.graphqlUtils.getJavaName(name);
+    }
+
+	protected String getPrefix() {
+		return "";
+	}
+	protected String getSuffix() {
+		return "";
 	}
 
 	/** {@inheritDoc} */

--- a/graphql-maven-plugin-logic/src/main/java/com/graphql_java_generator/plugin/language/impl/EnumType.java
+++ b/graphql-maven-plugin-logic/src/main/java/com/graphql_java_generator/plugin/language/impl/EnumType.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package com.graphql_java_generator.plugin.language.impl;
 
@@ -70,6 +70,16 @@ public class EnumType extends AbstractType {
 	@Override
 	public boolean isScalar() {
 		return true;
+	}
+
+	@Override
+	protected String getPrefix() {
+		return configuration.getEnumPrefix();
+	}
+
+	@Override
+	protected String getSuffix() {
+		return configuration.getEnumSuffix();
 	}
 
 }

--- a/graphql-maven-plugin-logic/src/main/java/com/graphql_java_generator/plugin/language/impl/InterfaceType.java
+++ b/graphql-maven-plugin-logic/src/main/java/com/graphql_java_generator/plugin/language/impl/InterfaceType.java
@@ -80,7 +80,7 @@ public class InterfaceType extends ObjectType {
 
 	@Override
 	protected String getSuffix() {
-		return configuration.getInterfacerSuffix();
+		return configuration.getInterfaceSuffix();
 	}
 
 	@Override

--- a/graphql-maven-plugin-logic/src/main/java/com/graphql_java_generator/plugin/language/impl/InterfaceType.java
+++ b/graphql-maven-plugin-logic/src/main/java/com/graphql_java_generator/plugin/language/impl/InterfaceType.java
@@ -74,6 +74,16 @@ public class InterfaceType extends ObjectType {
 	}
 
 	@Override
+	protected String getPrefix() {
+		return configuration.getUnionPrefix();
+	}
+
+	@Override
+	protected String getSuffix() {
+		return configuration.getUnionSuffix();
+	}
+
+	@Override
 	public String toString() {
 		return super.toString();
 	}

--- a/graphql-maven-plugin-logic/src/main/java/com/graphql_java_generator/plugin/language/impl/InterfaceType.java
+++ b/graphql-maven-plugin-logic/src/main/java/com/graphql_java_generator/plugin/language/impl/InterfaceType.java
@@ -75,12 +75,12 @@ public class InterfaceType extends ObjectType {
 
 	@Override
 	protected String getPrefix() {
-		return configuration.getUnionPrefix();
+		return configuration.getInterfacePrefix();
 	}
 
 	@Override
 	protected String getSuffix() {
-		return configuration.getUnionSuffix();
+		return configuration.getInterfacerSuffix();
 	}
 
 	@Override

--- a/graphql-maven-plugin-logic/src/main/java/com/graphql_java_generator/plugin/language/impl/ObjectType.java
+++ b/graphql-maven-plugin-logic/src/main/java/com/graphql_java_generator/plugin/language/impl/ObjectType.java
@@ -123,6 +123,16 @@ public class ObjectType extends AbstractType {
 	}
 
 	@Override
+	protected String getPrefix() {
+		return isInputType() ? getConfiguration().getInputPrefix() : getConfiguration().getTypePrefix();
+	}
+
+	@Override
+	protected String getSuffix() {
+		return isInputType() ? getConfiguration().getInputSuffix() : getConfiguration().getTypeSuffix();
+	}
+
+	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 		boolean addSeparator;

--- a/graphql-maven-plugin-logic/src/main/java/com/graphql_java_generator/plugin/language/impl/UnionType.java
+++ b/graphql-maven-plugin-logic/src/main/java/com/graphql_java_generator/plugin/language/impl/UnionType.java
@@ -42,6 +42,16 @@ public class UnionType extends ObjectType {
 	}
 
 	@Override
+	protected String getPrefix() {
+		return configuration.getUnionPrefix();
+	}
+
+	@Override
+	protected String getSuffix() {
+		return configuration.getUnionSuffix();
+	}
+
+	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
 		sb.append("UnionType {name=" + getName() + ", members=[");

--- a/graphql-maven-plugin-logic/src/main/resources/templates/interface_type.vm.java
+++ b/graphql-maven-plugin-logic/src/main/resources/templates/interface_type.vm.java
@@ -18,7 +18,7 @@ import $import;
  */
 ${object.annotation}
 @SuppressWarnings("unused")
-public interface ${object.javaName} #if($object.implementz.size()>0)extends #foreach($impl in $object.implementz)$impl#if($foreach.hasNext), #end#end#end {
+public interface ${object.javaName} #if($object.implementz.size()>0)extends #foreach($impl in $object.implementedTypes)$impl.javaName#if($foreach.hasNext), #end#end#end {
 #foreach ($field in $object.fields)
 
 #if ($field.comments.size() > 0)

--- a/graphql-maven-plugin-logic/src/main/resources/templates/object_type.vm.java
+++ b/graphql-maven-plugin-logic/src/main/resources/templates/object_type.vm.java
@@ -31,8 +31,8 @@ ${object.annotation}
 @JsonInclude(Include.NON_NULL)
 #end
 @SuppressWarnings("unused")
-public class ${targetFileName} 
-#if($object.implementz.size()>0)	implements #foreach($impl in $object.implementz)$impl#if($foreach.hasNext), #end#end#end
+public class ${targetFileName}
+#if($object.implementz.size()>0)	implements #foreach($impl in $object.implementedTypes)$impl.javaName#if($foreach.hasNext), #end#end#end
 #if($configuration.isGenerateJacksonAnnotations() && ${object.requestType})	#if($object.implementz.size()>0),#else implements#end com.graphql_java_generator.client.GraphQLRequestObject#end
 {
 ##

--- a/graphql-maven-plugin-logic/src/test/java/com/graphql_java_generator/plugin/PluginConfigurationTest.java
+++ b/graphql-maven-plugin-logic/src/test/java/com/graphql_java_generator/plugin/PluginConfigurationTest.java
@@ -33,6 +33,36 @@ class PluginConfigurationTest {
 
 		pluginConfiguration.scanBasePackages = "  a.b.c    ,    d.e.f  ";
 		assertEquals(",\"a.b.c\",\"d.e.f\"", pluginConfiguration.getQuotedScanBasePackages());
+
+		pluginConfiguration.typePrefix = "typePrefix";
+		assertEquals("typePrefix", pluginConfiguration.getTypePrefix());
+
+		pluginConfiguration.typeSuffix = "typeSuffix";
+		assertEquals("typeSuffix", pluginConfiguration.getTypeSuffix());
+
+		pluginConfiguration.inputPrefix = "inputPrefix";
+		assertEquals("inputPrefix", pluginConfiguration.getInputPrefix());
+
+		pluginConfiguration.inputSuffix = "inputSuffix";
+		assertEquals("inputSuffix", pluginConfiguration.getInputSuffix());
+
+		pluginConfiguration.unionPrefix = "unionPrefix";
+		assertEquals("unionPrefix", pluginConfiguration.getUnionPrefix());
+
+		pluginConfiguration.unionSuffix = "unionSuffix";
+		assertEquals("unionSuffix", pluginConfiguration.getUnionSuffix());
+
+		pluginConfiguration.interfacePrefix = "interfacePrefix";
+		assertEquals("interfacePrefix", pluginConfiguration.getInterfacePrefix());
+
+		pluginConfiguration.interfaceSuffix = "interfaceSuffix";
+		assertEquals("interfaceSuffix", pluginConfiguration.getInterfaceSuffix());
+
+		pluginConfiguration.enumPrefix = "enumPrefix";
+		assertEquals("enumPrefix", pluginConfiguration.getEnumPrefix());
+
+		pluginConfiguration.enumSuffix = "enumSuffix";
+		assertEquals("enumSuffix", pluginConfiguration.getEnumSuffix());
 	}
 
 }

--- a/graphql-maven-plugin-logic/src/test/java/com/graphql_java_generator/plugin/language/impl/AbstractTypeTest.java
+++ b/graphql-maven-plugin-logic/src/test/java/com/graphql_java_generator/plugin/language/impl/AbstractTypeTest.java
@@ -13,7 +13,7 @@ import com.graphql_java_generator.plugin.test.helper.GraphQLConfigurationTestHel
 
 class AbstractTypeTest {
 
-	GraphQLConfiguration pluginConfiguration = new GraphQLConfigurationTestHelper(this);
+	GraphQLConfigurationTestHelper pluginConfiguration = new GraphQLConfigurationTestHelper(this);
 
 	@Test
 	void testAddImportClassOfQ() {
@@ -90,4 +90,34 @@ class AbstractTypeTest {
 		assertTrue(type.getImports().contains("com.fasterxml.jackson.annotation.JsonTypeInfo.Id2"));
 	}
 
+	@Test
+	void testGetJavaNamePrefixAndSuffix() {
+
+		ObjectType typeObject = new ObjectType("MyType", pluginConfiguration, null);
+		pluginConfiguration.typePrefix = "TypePrefix";
+		pluginConfiguration.typeSuffix = "TypeSuffix";
+		assertEquals("TypePrefixMyTypeTypeSuffix", typeObject.getJavaName());
+
+		ObjectType inputObject = new ObjectType("MyInput", pluginConfiguration, null);
+		inputObject.setInputType(true);
+		pluginConfiguration.inputPrefix = "InputPrefix";
+		pluginConfiguration.inputSuffix = "InputSuffix";
+		assertEquals("InputPrefixMyInputInputSuffix", inputObject.getJavaName());
+
+		InterfaceType interfaceObject = new InterfaceType("MyInterface", pluginConfiguration, null);
+		pluginConfiguration.interfacePrefix = "InterfacePrefix";
+		pluginConfiguration.interfaceSuffix = "InterfaceSuffix";
+		assertEquals("InterfacePrefixMyInterfaceInterfaceSuffix", interfaceObject.getJavaName());
+
+		UnionType unionObject = new UnionType("MyUnion", pluginConfiguration, null);
+		pluginConfiguration.unionPrefix = "UnionPrefix";
+		pluginConfiguration.unionSuffix = "UnionSuffix";
+		assertEquals("UnionPrefixMyUnionUnionSuffix", unionObject.getJavaName());
+
+		EnumType enumObject = new EnumType("MyEnum", pluginConfiguration, null);
+		pluginConfiguration.enumPrefix = "EnumPrefix";
+		pluginConfiguration.enumSuffix = "EnumSuffix";
+		assertEquals("EnumPrefixMyEnumEnumSuffix", enumObject.getJavaName());
+
+	}
 }

--- a/graphql-maven-plugin-logic/src/test/java/com/graphql_java_generator/plugin/test/helper/GenerateGraphQLSchemaConfigurationTestHelper.java
+++ b/graphql-maven-plugin-logic/src/test/java/com/graphql_java_generator/plugin/test/helper/GenerateGraphQLSchemaConfigurationTestHelper.java
@@ -13,7 +13,7 @@ import com.graphql_java_generator.plugin.conf.GenerateGraphQLSchemaConfiguration
 import lombok.Getter;
 
 /**
- * 
+ *
  * @author etienne-sf
  */
 @Getter
@@ -34,6 +34,17 @@ public class GenerateGraphQLSchemaConfigurationTestHelper implements GenerateGra
 	public File targetFolder = null;
 	public String targetSchemaFileName = null;
 	public Map<String, String> templates = new HashMap<String, String>();
+
+	public String typePrefix = "";
+	public String typeSuffix = "";
+	public String unionPrefix = "";
+	public String unionSuffix = "";
+	public String enumPrefix = "";
+	public String enumSuffix = "";
+	public String interfacePrefix = "";
+	public String interfaceSuffix = "";
+	public String inputPrefix = "";
+	public String inputSuffix = "";
 
 	/**
 	 * @param caller

--- a/graphql-maven-plugin-logic/src/test/java/com/graphql_java_generator/plugin/test/helper/GraphQLConfigurationTestHelper.java
+++ b/graphql-maven-plugin-logic/src/test/java/com/graphql_java_generator/plugin/test/helper/GraphQLConfigurationTestHelper.java
@@ -63,6 +63,17 @@ public class GraphQLConfigurationTestHelper implements GraphQLConfiguration {
 	public File targetSourceFolder = null;
 	public Map<String, String> templates = new HashMap<String, String>();
 
+	public String typePrefix = "";
+	public String typeSuffix = "";
+	public String unionPrefix = "";
+	public String unionSuffix = "";
+	public String enumPrefix = "";
+	public String enumSuffix = "";
+	public String interfacePrefix = "";
+	public String interfaceSuffix = "";
+	public String inputPrefix = "";
+	public String inputSuffix = "";
+
 	/**
 	 * @param caller
 	 *            Used to retrieve the appropriate Log4j logger

--- a/graphql-maven-plugin/src/main/java/com/graphql_java_generator/mavenplugin/AbstractCommonMojo.java
+++ b/graphql-maven-plugin/src/main/java/com/graphql_java_generator/mavenplugin/AbstractCommonMojo.java
@@ -130,6 +130,66 @@ public abstract class AbstractCommonMojo extends AbstractMojo implements CommonC
 	Map<String, String> templates;
 
 	/**
+	 *  An optional prefix for the generated java classes for GraphQL types.
+	 */
+	@Parameter(property = "com.graphql_java_generator.mavenplugin.typePrefix", defaultValue = "")
+	public String typePrefix;
+
+	/**
+	 *  An optional suffix for the generated java classes for GraphQL types.
+	 */
+	@Parameter(property = "com.graphql_java_generator.mavenplugin.typeSuffix", defaultValue = "")
+	public String typeSuffix;
+
+	/**
+	 *  An optional prefix for the generated java classes for GraphQL unions.
+	 */
+	@Parameter(property = "com.graphql_java_generator.mavenplugin.unionPrefix", defaultValue = "")
+	public String unionPrefix;
+
+	/**
+	 *  An optional suffix for the generated java classes for GraphQL unions.
+	 */
+	@Parameter(property = "com.graphql_java_generator.mavenplugin.unionSuffix", defaultValue = "")
+	public String unionSuffix;
+
+	/**
+	 *  An optional prefix for the generated java classes for GraphQL enums.
+	 */
+	@Parameter(property = "com.graphql_java_generator.mavenplugin.enumPrefix", defaultValue = "")
+	public String enumPrefix;
+
+	/**
+	 *  An optional suffix for the generated java classes for GraphQL enums.
+	 */
+	@Parameter(property = "com.graphql_java_generator.mavenplugin.enumSuffix", defaultValue = "")
+	public String enumSuffix;
+
+	/**
+	 *  An optional prefix for the generated java classes for GraphQL interfaces.
+	 */
+	@Parameter(property = "com.graphql_java_generator.mavenplugin.interfacePrefix", defaultValue = "")
+	public String interfacePrefix;
+
+	/**
+	 *  An optional suffix for the generated java classes for GraphQL interfaces.
+	 */
+	@Parameter(property = "com.graphql_java_generator.mavenplugin.interfaceSuffix", defaultValue = "")
+	public String interfaceSuffix;
+
+	/**
+	 *  An optional prefix for the generated java classes for GraphQL input objects.
+	 */
+	@Parameter(property = "com.graphql_java_generator.mavenplugin.inputPrefix", defaultValue = "")
+	public String inputPrefix;
+
+	/**
+	 *  An optional suffix for the generated java classes for GraphQL input objects.
+	 */
+	@Parameter(property = "com.graphql_java_generator.mavenplugin.javaClassSuffix", defaultValue = "")
+	public String inputSuffix;
+
+	/**
 	 * This class contains the Spring configuration for the actual instance of this Mojo. It's set by subclasses,
 	 * through the constructor
 	 */
@@ -163,7 +223,47 @@ public abstract class AbstractCommonMojo extends AbstractMojo implements CommonC
 		return templates;
 	}
 
-	@Override
+    public String getTypePrefix() {
+        return typePrefix;
+    }
+
+    public String getTypeSuffix() {
+        return typeSuffix;
+    }
+
+    public String getInputPrefix() {
+        return inputPrefix;
+    }
+
+    public String getInputSuffix() {
+        return inputSuffix;
+    }
+
+    public String getUnionPrefix() {
+        return unionPrefix;
+    }
+
+    public String getUnionSuffix() {
+        return unionSuffix;
+    }
+
+    public String getInterfacePrefix() {
+        return interfacePrefix;
+    }
+
+    public String getInterfaceSuffix() {
+        return interfaceSuffix;
+    }
+
+    public String getEnumPrefix() {
+        return enumPrefix;
+    }
+
+    public String getEnumSuffix() {
+        return enumSuffix;
+    }
+
+    @Override
 	public boolean isSkipGenerationIfSchemaHasNotChanged() {
 		return skipGenerationIfSchemaHasNotChanged;
 	}


### PR DESCRIPTION
To support using graphql-maven-plugin instead of another code generator in an existing code base, the code generator is extended to support adding custom prefixes and suffixes on the generated java classes.

The need for this change was identified when trying to replace an old code generator in a very large code base.
The old generator is using a naming scheme with a suffix for input objects and types, where for example the type Droid would be named DroidGraphQLType (similarly for interfaces and enums). The code base have thousands of usages of these classes, making it risky to migrate all existing code, especially because there are existing classes (domain objects, and enums) used in the data fetchers, with the same class name as those that would be generated without a suffix.

The plugin is extended with configuration options 

```

	/**
	 *  An optional prefix for the generated java classes for GraphQL types.
	 */
	@Parameter(property = "com.graphql_java_generator.mavenplugin.typePrefix", defaultValue = "")
	public String typePrefix;

	/**
	 *  An optional suffix for the generated java classes for GraphQL types.
	 */
	@Parameter(property = "com.graphql_java_generator.mavenplugin.typeSuffix", defaultValue = "")
	public String typeSuffix;

	/**
	 *  An optional prefix for the generated java classes for GraphQL unions.
	 */
	@Parameter(property = "com.graphql_java_generator.mavenplugin.unionPrefix", defaultValue = "")
	public String unionPrefix;

	/**
	 *  An optional suffix for the generated java classes for GraphQL unions.
	 */
	@Parameter(property = "com.graphql_java_generator.mavenplugin.unionSuffix", defaultValue = "")
	public String unionSuffix;

	/**
	 *  An optional prefix for the generated java classes for GraphQL enums.
	 */
	@Parameter(property = "com.graphql_java_generator.mavenplugin.enumPrefix", defaultValue = "")
	public String enumPrefix;

	/**
	 *  An optional suffix for the generated java classes for GraphQL enums.
	 */
	@Parameter(property = "com.graphql_java_generator.mavenplugin.enumSuffix", defaultValue = "")
	public String enumSuffix;

	/**
	 *  An optional prefix for the generated java classes for GraphQL interfaces.
	 */
	@Parameter(property = "com.graphql_java_generator.mavenplugin.interfacePrefix", defaultValue = "")
	public String interfacePrefix;

	/**
	 *  An optional suffix for the generated java classes for GraphQL interfaces.
	 */
	@Parameter(property = "com.graphql_java_generator.mavenplugin.interfaceSuffix", defaultValue = "")
	public String interfaceSuffix;

	/**
	 *  An optional prefix for the generated java classes for GraphQL input objects.
	 */
	@Parameter(property = "com.graphql_java_generator.mavenplugin.inputPrefix", defaultValue = "")
	public String inputPrefix;

	/**
	 *  An optional suffix for the generated java classes for GraphQL input objects.
	 */
	@Parameter(property = "com.graphql_java_generator.mavenplugin.javaClassSuffix", defaultValue = "")
	public String inputSuffix;
```

Tests have been added to verify the configuration and code generation.
